### PR TITLE
presale mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Name | Possible Values | Description
 `issuingPublicKey` | Stellar public key | Public key of issuing account
 `assetCode` | `string` | Asset code of token to sell, ex. `TOKE`
 `price` | `string` | Maximum price of 1 `assetCode` token (in `BTC` or `ETH` depending which `start*` method is used)
-`bifrostURL` | `string` | URL of Bifrost server
-`horizonURL` | `string` | URL of Horizon server (_do not use SDF's servers!_)
+`bifrostURL`  | `string`  | URL of Bifrost server
+`horizonURL`  | `string`  | URL of Horizon server (_do not use SDF's servers!_)
+`preSaleMode` | `boolean` | (Optional) If set to `true`, tokens will not be sent to immediately to the user
 
 Example: 
 ```js
@@ -34,6 +35,7 @@ var params = {
   assetCode: 'TOKE',
   price: '1',
   issuingPublicKey: 'GDGVTKSEXWB4VFTBDWCBJVJZLIY6R3766EHBZFIGK2N7EQHVV5UTA63C',
+  preSaleMode: false,
 };
 
 var session = new Bifrost.Session(params);

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Name | Possible Values | Description
 `price` | `string` | Maximum price of 1 `assetCode` token (in `BTC` or `ETH` depending which `start*` method is used)
 `bifrostURL`  | `string`  | URL of Bifrost server
 `horizonURL`  | `string`  | URL of Horizon server (_do not use SDF's servers!_)
-`preSaleMode` | `boolean` | (Optional) If set to `true`, tokens will not be sent to immediately to the user
+`preSaleMode` | `boolean` | (Optional) If set to `true`, BTC/ETH tokens will not be traded to `assetCode`. User will end up with BTC/ETH in their Stellar account.
 
 Example: 
 ```js

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ session.startEthereum(onEvent).then({address, keypair} => {
 `Bifrost.AccountCreatedEvent` | _none_ | Sent when account is created
 `Bifrost.TrustLinesCreatedEvent` | _none_ | Sent when trust line is created
 `Bifrost.AccountCreditedEvent` | _none_ | Sent when account is credited
-`Bifrost.PurchasedEvent` | _none_ | Sent when token is purchased
-`Bifrost.ErrorEvent` | `Error` object | Sent when asynchronous, nonrecoverable error occured
+`Bifrost.PurchasedEvent` (This will not be triggered in `preSaleMode`) | _none_ | Sent when token is purchased
+`Bifrost.ErrorEvent` | `Error` object | Sent when asynchronous, non-recoverable error occured
 
 Example:
 ```js

--- a/example.html
+++ b/example.html
@@ -43,6 +43,7 @@
     assetCode: 'TOKE',
     price: '1',
     issuingPublicKey: 'GDGVTKSEXWB4VFTBDWCBJVJZLIY6R3766EHBZFIGK2N7EQHVV5UTA63C',
+    preSaleMode: false,
   };
 
   var session = new Bifrost.Session(params);

--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,10 @@ export class Session {
       .then(sourceAccount => {
         this._onAccountCreditedRecoveryTransactions(sourceAccount.sequenceNumber(), assetCode, amount);
 
+        if(this.params.preSaleMode){
+          return;
+        }
+
         var transaction = new TransactionBuilder(sourceAccount)
           .addOperation(Operation.manageOffer({
             selling: new Asset(assetCode, this.params.issuingPublicKey),


### PR DESCRIPTION
This adds a `preSaleMode` to `params`. If enabled, tokens are not immediately sent to the user. Tokens will be sent manually by the issuer or the user can trade the IOU tokens for the actual tokens on SDEX.